### PR TITLE
RDF Datasets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,4 +30,8 @@ gradle-app.setting
 *.iws
 
 # output example
-output.ttl
+#output.ttl
+#output.trig
+
+# local documentation
+doc/

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ String2Vocabulary
 [![](https://jitpack.io/v/DOREMUS-ANR/string2vocabulary.svg)](https://jitpack.io/#DOREMUS-ANR/string2vocabulary)
 
 Look for literals in an RDF graph and substitute them with URIs from controlled vocabularies.
-Built with Gradle and Apache Jena.
+Built with [Gradle](https://gradle.org/) and [Apache Jena](https://jena.apache.org).
 
-It uses the the vocabulary filenames for grouping them in **families**. For example, `city-italy.ttl` and `city-france.ttl` are part of the family `city`.
+It uses the vocabulary filenames for grouping them in **families**. For example, `city-italy.ttl` and `city-france.ttl` are part of the family `city`.
 
 ## Input
 
@@ -27,7 +27,7 @@ ns:myMusicWork mus:U11_has_key [
    mus:U2_foresees_use_of_medium_of_performance "mezzosoprano" .
 ```
 
-this produces as output.
+... this produces as output:
 
 ```turtle
 ns:myMusicWork mus:U11_has_key <http://data.doremus.org/vocabulary/key/d> ;
@@ -36,13 +36,21 @@ ns:myMusicWork mus:U11_has_key <http://data.doremus.org/vocabulary/key/d> ;
 
 ## Features
 
-- 2 vocabulary syntax supported: SKOS and MODS
+- Vocabulary syntax supported:
+  - SKOS
+  - MODS
 - Support for families of vocabularies
 - Replace literals that match the given label
 - Replace objects that have a `rdfs:label` or `ecrm:P1_is_identified_by` which match the given label
 - _Strict mode_: match both label and language
 - Normalise the labels by removing punctuation, decoding to ASCII, using lowercase
 - Search also for the singular version of the word with [Stanford CoreNLP](https://github.com/stanfordnlp/CoreNLP)
+- Support for [RDF Dataset](https://www.w3.org/TR/sparql11-query/#rdfDataset):
+  - replace content at the *default graph* level
+  - replace content at a given *named graph* level
+- Supported textual syntax for RDF (serialization):
+  - [RDF Turtle](https://www.w3.org/TR/turtle/) (.ttl)
+  - [TriG](https://www.w3.org/TR/trig/) (.trig)
 
 Dependencies:
 * Build tool: [Gradle](https://gradle.org/) 7+
@@ -56,7 +64,7 @@ Dependencies:
 
   ```
   dependencies {
-     compile 'com.github.DOREMUS-ANR:string2vocabulary:0.2'
+     compile 'com.github.DOREMUS-ANR:string2vocabulary:0.7'
   }
   ```
 
@@ -77,6 +85,7 @@ Dependencies:
   // set the language to be used for singularising the words
   VocabularyManager.setLang("fr");
   ```
+
 3. Use it :)
 
 ```java
@@ -98,13 +107,11 @@ VocabularyManager.getVocabulary("mop-iaml").findConcept("violin@it", true);
 VocabularyManager.getVocabulary("key").getConcept("dm");
 // --> http://data.doremus.org/vocabulary/key/dm
 
-
 // or
 // Full graph replacement
 // search and substitute in the whole Jena Model
 // (following the csv configuration)
 VocabularyManager.string2uri(model)
-
 ```
 
 See the [test](src/test) folder for another example of usage.
@@ -117,23 +124,68 @@ Run the library from CLI with `gradle run`:
 gradle run -Pmap="/location/to/property2family.csv" \
   -Pinput="/location/to/input.ttl" \
   -Pvocabularies="/location/to/vocabularyFolder"
-
-# Example with test files provided
-gradle run -Pmap="src/test/resources/property2family.csv" \
-  -Pinput="src/test/resources/input.ttl" \
-  -Pvocabularies="src/test/resources/vocabulary"
 ```
+
+Available CLI parameters:
 
 | param | example | comment |
 | ----- | ------- | ------- |
 | map   | `/location/to/property2family.csv` | A table with mapping property-vocabulary |
 | vocabularies   | `/location/to/vocabularyFolder` | Folder containing the vocabularies in turtle format |
-| input   | `/location/to/input.ttl` | The input turtle file |
-| output _(Optional)_   | `/location/to/output.ttl` | The output turtle file. Default: `inputPath/inputName_output.ttl` |
+| input   | `/location/to/input.ttl` | The input file (Turtle or TriG syntax) |
+| output _(Optional)_   | `/location/to/output.ttl` | The output turtle file. Default: `<inputPath/inputName>_output.<inputFileExt>` |
 | lang  _(Optional)_  | `fr` | Language to be used for singularising the words. Default: `en`. |
+| graph _(Optional)_ | `http://example.org/graph/object/` | The [named graph](https://en.wikipedia.org/wiki/Named_graph) to process. Default: `` (i.e. the default graph) |
 
 Default `gradle run` behavior rely on *project properties* set in the [gradle.properties](gradle.properties) file.
 See the following links for details about *properties* in Gradle:
 * [Passing Command Line Arguments in Gradle](https://www.baeldung.com/gradle-command-line-arguments)
 * [Gradle project properties best practices](https://tomgregory.com/gradle-project-properties-best-practices/)
 * [Configuring Gradle with "gradle.properties" ](https://dev.to/jmfayard/configuring-gradle-with-gradle-properties-211k)
+
+CLI examples with provided test files:
+
+```shell
+# Example: Turtle syntax
+gradle run -Pmap="src/test/resources/property2family.csv" \
+  -Pinput="src/test/resources/input.ttl" \
+  -Pvocabularies="src/test/resources/vocabulary"
+
+# Example: TriG syntax, replace at the default graph level
+gradle run -Pmap="src/test/resources/property2family.csv" \
+  -Pinput="src/test/resources/input.trig" \
+  -Poutput="src/test/resources/output.trig" \
+  -Pvocabularies="src/test/resources/vocabulary"
+
+# Example: TriG syntax, replace at the default graph level (alternative)
+gradle run -Pmap="src/test/resources/property2family.csv" \
+  -Pinput="src/test/resources/input.trig" \
+  -Poutput="src/test/resources/output.trig" \
+  -Pvocabularies="src/test/resources/vocabulary" \
+  -Pgraph=""
+
+# Example: TriG syntax, replace at a given named graph level
+gradle run -Pmap="src/test/resources/property2family.csv" \
+  -Pinput="src/test/resources/input.trig" \
+  -Poutput="src/test/resources/output.trig" \
+  -Pvocabularies="src/test/resources/vocabulary" \
+  -Pgraph="http://example.org/graph/object/"
+```
+
+### Documentation
+
+Generating local code documentation:
+
+```shell
+javadoc -d doc/ ./org/doremus/string2vocabulary/VocabularyManager.java
+```
+
+References:
+
+* https://www.tutorialspoint.com/java/java_documentation.htm
+
+## Contribute
+
+In the general case, please
+* *fork and create merge request* OR
+* *raise an issue* into the project's space.

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 group 'org.doremus'
-version '0.6.1'
+version '0.7.0'
 
 apply plugin: 'java'
 apply plugin: 'application'
@@ -48,7 +48,8 @@ run {
                 '--lang', project.property('lang'),
                 '--input', project.property('input'),
                 '--output', project.property('output'),
-                '--vocabularies', project.property('vocabularies')
+                '--vocabularies', project.property('vocabularies'),
+                '--graph', project.property('graph')
         ]
     standardOutput = System.out
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,6 +3,9 @@
 # Default run properties (test example)
 map=src/test/resources/property2family.csv
 lang=en
+vocabularies=src/test/resources/vocabulary
+
 input=src/test/resources/input.ttl
 output=output.ttl
-vocabularies=src/test/resources/vocabulary
+
+graph=

--- a/src/main/java/org/doremus/string2vocabulary/VocabularyManager.java
+++ b/src/main/java/org/doremus/string2vocabulary/VocabularyManager.java
@@ -4,9 +4,10 @@ import org.apache.jena.query.*;
 import org.apache.jena.rdf.model.*;
 import org.apache.jena.rdf.model.impl.StatementImpl;
 import org.apache.jena.riot.RDFDataMgr;
+import org.apache.jena.riot.Lang;
 
 import java.io.File;
-import java.io.FileWriter;
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.net.URL;
 import java.nio.file.Files;
@@ -16,6 +17,13 @@ import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+/**
+ * The VocabularyManager class
+ *
+ * @author Pasquale Lisena
+ * @since 2017-11-09
+ * @see https://github.com/DOREMUS-ANR/string2vocabulary
+ */
 public class VocabularyManager {
   private static List<Vocabulary> vocabularies;
   private static Map<String, List<Vocabulary>> vocabularyMap;
@@ -27,61 +35,82 @@ public class VocabularyManager {
                           " { ?s ?p ?o . ?o rdfs:label | ecrm:P1_is_identified_by ?label }\n" +
                           " UNION\n" +
                           " { ?s ?p ?label }\n" +
-                          " FILTER(isLiteral(?label))}");
+                          " FILTER(isLiteral(?label))} ");
   private static Map<Property, PropMap> prop2FamilyMap;
   private static boolean verbose = false;
   private static String vocabularyDirPath;
   private static StanfordLemmatizer slem;
   private static String lang = "en";
 
-  public static void init(URL property2FamilyResource) throws IOException {
-    init(property2FamilyResource.getFile());
+  // === Helper methods =======================================================
+
+  /**
+   * String handling approach to finding the extension.
+   * This method will check for the dot ‘.' occurrence in the given filename.
+   * If it exists, then it will find the last position of the dot ‘.' and return the characters after that, the characters after the last dot ‘.' known as the file extension.
+   *
+   * Special Cases:
+   *   No extension – this method will return an empty String
+   *   Only extension – this method will return the String after the dot, e.g. “gitignore”
+   * Source: https://www.baeldung.com/java-file-extension
+   * @param filename
+   * @return String
+   */
+  public static Optional<String> getExtensionByStringHandling(String filename) {
+    return Optional.ofNullable(filename)
+      .filter(f -> f.contains("."))
+      .map(f -> f.substring(filename.lastIndexOf(".") + 1));
   }
 
-  public static void init(String property2FamilyCSV) throws IOException {
-    init(getMapFromCSV(Paths.get(property2FamilyCSV)));
-  }
-
-  public static void init(Map<Property, PropMap> property2FamilyMap) {
-    vocabularies = new ArrayList<>();
-    vocabularyMap = new HashMap<>();
-
-    prop2FamilyMap = property2FamilyMap;
-
-    // load vocabularies from resource folder
-    File vocabularyDir = new File(vocabularyDirPath);
-
-    File[] files = vocabularyDir.listFiles((dir, name) -> name.toLowerCase().endsWith(".ttl"));
-    assert files != null;
-
-    for (File file : files) {
-      Vocabulary vocabulary = Vocabulary.fromFile(file);
-      if (vocabulary == null) continue;
-      vocabularies.add(vocabulary);
-
-      List<Vocabulary> thisCategory = vocabularyMap.computeIfAbsent(vocabulary.getCategory(), k -> new ArrayList<>());
-      thisCategory.add(vocabulary);
-      Collections.sort(thisCategory);
-    }
-
-    Collections.sort(vocabularies);
-
-    setLang(lang);
-  }
-
+  /**
+   * Load the property-vocabulary mapping from a CSV file into a Map object (an object that maps keys to values)
+   * @param path Path to the property-vocabulary mapping file
+   * @return Map<Property, PropMap>
+   * @throws IOException
+   */
   private static Map<Property, PropMap> getMapFromCSV(final Path path) throws IOException {
     Model m = ModelFactory.createDefaultModel();
 
     Stream<String> lines = Files.lines(path);
     Map<Property, PropMap> resultMap = lines.map(PropMap::new)
-            .collect(Collectors.toMap(pm -> m.createProperty(pm.getProperty()), pm -> pm));
+      .collect(Collectors.toMap(pm -> m.createProperty(pm.getProperty()), pm -> pm));
     lines.close();
 
     return resultMap;
   }
 
+  /**
+   * Helper method for retrieving the value of given parameter
+   * @param params A set of key/value parameters
+   * @param key The parameter key to read
+   * @return String
+   */
+  private static String getParam(List<String> params, String key) {
+    int i = params.indexOf(key);
+    if (i < 0) return null;
+    return params.get(i + 1);
+  }
+
+  // === Class properties setter/getter =======================================
+
+  /**
+   * Setter for the logging verbosity
+   */
+  public static void setVerbose(boolean verbose) {
+    VocabularyManager.verbose = verbose;
+  }
+
+  /**
+   * Setter for the reference vocabulary folder
+   */
+  public static void setVocabularyFolder(String vocabularyFolder) {
+    vocabularyDirPath = vocabularyFolder;
+  }
+
+  /**
+   * Setter for lemmatiser
+   */
   public static void setLang(String _lang) {
-    // for lemmatiser
     lang = _lang;
     slem = new StanfordLemmatizer(lang);
   }
@@ -102,12 +131,15 @@ public class VocabularyManager {
     return vocabularyMap.get(category);
   }
 
-  public static void string2uri(Model m) {
-    prop2FamilyMap.forEach((key, value) -> propertyMatching(m, key, value.getCategory(), value.singularise()));
-  }
+  // === Processing methods ===================================================
 
-
-  private static Model propertyMatching(Model model, Property property, String category, boolean singularise) {
+  /**
+   * Queries the model for a given property and substitutes objects with relevant vocabulary URI if any.
+   */
+  private static Model propertyMatching(Model model,
+                                        Property property,
+                                        String category,
+                                        boolean singularise) {
     int count = 0;
     List<Statement> statementsToRemove = new ArrayList<>(),
             statementsToAdd = new ArrayList<>();
@@ -126,9 +158,11 @@ public class VocabularyManager {
         Resource subject = res.get("s").asResource();
         if (res.get("o") != null) {
           Resource object = res.get("o").asResource();
+
           // remove all properties of the object
           for (StmtIterator it = object.listProperties(); it.hasNext(); )
             statementsToRemove.add(it.nextStatement());
+
           // remove the link between the object and the subject
           statementsToRemove.add(new StatementImpl(subject, property, object));
         } else
@@ -141,13 +175,41 @@ public class VocabularyManager {
       model.remove(statementsToRemove);
       model.add(statementsToAdd);
 
-      if (verbose) System.out.println("Matched " + count + " elements for " + property.getLocalName());
+      if (verbose) System.out.println("Matched " + count + " elements for " + property.getLocalName());  // TODO: use logging facilities
     } catch (RuntimeException re) {
-      System.out.println(re.getMessage());
+      System.out.println(re.getMessage());  // TODO: use logging facilities
     }
     return model;
   }
 
+  /**
+   * Search for a term in a given family.
+   * This performs a normal full search and one in strict mode.
+   */
+  public static String runSearchInCategory(String vocabularyFolder,
+                                           String label,
+                                           String singularizationLang,
+                                           String lookupLang,
+                                           String category) {
+
+    // print full logs
+    VocabularyManager.setVerbose(true);
+
+    if (vocabularyFolder == null || label == null || lang == null || category == null) {
+      return null;
+    } else {
+
+      // set the folder where to find vocabularies
+      VocabularyManager.setVocabularyFolder(vocabularyFolder);
+
+      // set the language to be used for singularizing the words
+      VocabularyManager.setLang(singularizationLang);
+
+      // Search for a term in a given family
+      // this performs a normal full search and one in strict mode
+      return VocabularyManager.searchInCategory(label, lookupLang, category, true).toString();
+    }
+  }
 
   public static Resource searchInCategory(String label, String lang, String category, boolean singularise) throws RuntimeException {
     try {
@@ -209,12 +271,23 @@ public class VocabularyManager {
     return null;
   }
 
+  /**
+   * Iterate over the properties to map lists and query the model instance (input dataset) for statements.
+   */
+  public static void string2uri(Model m) {
+    prop2FamilyMap.forEach((key, value) -> propertyMatching(
+      m,
+      key,
+      value.getCategory(),
+      value.singularise())
+    );
+  }
+
   private static String toSingular(String r, boolean full) {
     if (r == null || r.isEmpty()) return "";
     if (full)
       return slem.lemmatize(r).stream()
               .collect(Collectors.joining(" "));
-
 
     String[] parts = r.split(" ");
     if (parts.length == 1) return slem.lemmatize(parts[0]).get(0);
@@ -224,56 +297,196 @@ public class VocabularyManager {
     return String.join(" ", parts);
   }
 
+  // === Run methods ==========================================================
 
-  public static void run(String property2family, String vocabularyFolder, Model m, String outputFile) throws IOException {
-    run(property2family, vocabularyFolder, m, outputFile, "en");
+  /**
+   * Shortcut to the *init* method with property-vocabulary mapping as a URL
+   */
+  public static void init(URL property2FamilyResource) throws IOException {
+    init(property2FamilyResource.getFile());
   }
 
-  public static void run(String property2family, String vocabularyFolder, Model m, String outputFile, String lang) throws IOException {
-    // full run for standalone script
+  /**
+   * Shortcut to the *init* method with property-vocabulary mapping as a file path
+   */
+  public static void init(String property2FamilyCSV) throws IOException {
+    init(getMapFromCSV(Paths.get(property2FamilyCSV)));
+  }
+
+  /**
+   * VocabularyManager initialisation procedure.
+   * Basically,
+   * - instanciates fundamental objects
+   * - loads vocabularies from resource folder
+   */
+  public static void init(Map<Property, PropMap> property2FamilyMap) {
+    vocabularies = new ArrayList<>();
+    vocabularyMap = new HashMap<>();
+
+    prop2FamilyMap = property2FamilyMap;
+
+    // load vocabularies from resource folder
+    File vocabularyDir = new File(vocabularyDirPath);
+
+    File[] files = vocabularyDir.listFiles((dir, name) -> name.toLowerCase().endsWith(".ttl"));
+    assert files != null;
+
+    for (File file : files) {
+      Vocabulary vocabulary = Vocabulary.fromFile(file);
+      if (vocabulary == null) continue;
+      vocabularies.add(vocabulary);
+
+      List<Vocabulary> thisCategory = vocabularyMap.computeIfAbsent(vocabulary.getCategory(), k -> new ArrayList<>());
+      thisCategory.add(vocabulary);
+      Collections.sort(thisCategory);
+    }
+
+    Collections.sort(vocabularies);
+
+    setLang(lang);
+  }
+
+  /**
+   * Shortcut to the *run* method with lang set to "en"
+   */
+  public static void run(String property2family,
+                         String vocabularyFolder,
+                         Dataset dataset,
+                         String namedGraph,
+                         Model m,
+                         String outputFile) throws IOException {
+    run(
+      property2family,
+      vocabularyFolder,
+      dataset,
+      namedGraph,
+      m,
+      outputFile,
+      "en"
+    );
+  }
+
+  /**
+   * Full run of the patching process for standalone script
+   * @param property2family Table file with property-vocabulary mapping
+   * @param vocabularyFolder Folder containing the vocabularies in turtle format
+   * @param m The model instance (input dataset)
+   * @param outputFile Filename for saving the resulting dataset
+   * @param lang Language to be used for singularising the words, e.g. 'en"
+   */
+  public static void run(String property2family,
+                         String vocabularyFolder,
+                         Dataset dataset,
+                         String namedGraph,
+                         Model m,
+                         String outputFile,
+                         String lang) throws IOException {
+
+    // Vocabulary manager init
     VocabularyManager.setVerbose(true);
     VocabularyManager.setVocabularyFolder(vocabularyFolder);
     VocabularyManager.init(property2family);
     VocabularyManager.setLang(lang);
+
+    // Call processing
     VocabularyManager.string2uri(m);
 
+    // Breaks on no output file config
     if (outputFile == null) return;
 
-    FileWriter out = new FileWriter(outputFile);
-    m.write(out, "TURTLE");
-
+    // Save results to file
+    // TODO: give the opportunity to save the dataset with patched data VS only the patched model
+    System.out.println("Saving data: to '" + outputFile + "' ...");  // TODO: use logging facilities
+    FileOutputStream out = new FileOutputStream(outputFile, false);
+    // Remark: we assume below that Lang.TRIG encompasses both the Turtle and TriG syntax for serialization
+    RDFDataMgr.write(out, dataset.asDatasetGraph(), Lang.TRIG);
     out.close();
+    System.out.println("Saving data: to '" + outputFile + "' ... done.");  // TODO: use logging facilities
   }
 
-  public static void setVerbose(boolean verbose) {
-    VocabularyManager.verbose = verbose;
-  }
-
-  public static void setVocabularyFolder(String vocabularyFolder) {
-    vocabularyDirPath = vocabularyFolder;
-  }
-
+  /**
+   * Program entrypoint
+   * Process:
+   * - get running arguments
+   * - load the data to process into a JENA object, see https://jena.apache.org/documentation/io/rdf-input.html
+   * - start the data processing.
+   */
   public static void main(String args[]) throws IOException {
+
+    // Get params
     List<String> params = Arrays.asList(args);
 
-    String property2family = getParam(params, "--map");
-    String input = getParam(params, "--input");
-    String vocabularyFolder = getParam(params, "--vocabularies");
-    String output = getParam(params, "--output");
-    if (output == null) output = input.replace(".ttl", "_output.ttl");
+    // Load params
     String lang = getParam(params, "--lang");
-    System.out.println("Config:map='" + property2family + "':input='" + input + "':vocabularies='" + vocabularyFolder + "':output='" + output + "':lang='" + lang + "'.");
+    String namedGraph = getParam(params, "--graph");  // Example: "http://example.org/graph/object/"
+    String property2family = getParam(params, "--map");
+    String vocabularyFolder = getParam(params, "--vocabularies");
 
+    // Load params - get input file
+    String input = getParam(params, "--input");
+    String fileExt = getExtensionByStringHandling(input).orElse("none").toLowerCase();
+    if (fileExt.isEmpty()) {
+      System.out.println("ERROR: file extension looks empty (should be .ttl or .trig).");  // TODO: use logging facilities
+      System.exit(1);
+    }
 
-    Model mi = RDFDataMgr.loadModel(input);
-    VocabularyManager.run(property2family, vocabularyFolder, mi, output, lang);
+    // Check input file exists
+    // This allows to prevent the `org.apache.jena.riot.RiotNotFoundException: Not found` exception at the loadDataset/loadModel statement for cleaner exit when the input file does not exist.
+    File f = new File(input);
+    if(!f.exists() && !f.isDirectory()) {
+      System.out.println("ERROR: file '"+input+"' doesn't exist.");  // TODO: use logging facilities
+      System.exit(1);
+    }
 
-  }
+    // Load params - assert output file name
+    String output = getParam(params, "--output");
+    if (output == null | output.isEmpty()) output = input.replace(
+      "." + fileExt,
+      "_output." + fileExt);
 
-  private static String getParam(List<String> params, String key) {
-    int i = params.indexOf(key);
-    if (i < 0) return null;
-    return params.get(i + 1);
+    // Log params
+    System.out.println(
+      "Config:map='" + property2family +
+        "':input='" + input +
+        "':input(fileExt)='" + fileExt +
+        "':vocabularies='" + vocabularyFolder +
+        "':output='" + output +
+        "':lang='" + lang +
+        "'."
+    );  // TODO: use logging facilities
+
+    // Load the dataset
+    // See https://jena.apache.org/documentation/javadoc/arq/org.apache.jena.arq/org/apache/jena/riot/RDFDataMgr.html
+    // Remark: loadDataset() automatically detects the serialization based on the file extension, hence it is useless to call `loadDataset(input, Lang.XXX) if the extension is explicit.
+    Dataset dataset = RDFDataMgr.loadDataset(input);
+
+    // Make a model instance (mi) from the dataset and named graph (if relevant)
+    Model mi;
+    if (namedGraph == null || namedGraph.isEmpty()) {
+      // Get the default graph as a Jena Model
+      System.out.println("Loading model: from default graph...");  // TODO: use logging facilities
+      mi = dataset.getDefaultModel();
+    } else {
+      // Get a graph by name as a Jena Model
+      System.out.println("Loading model: from '" + namedGraph + "' graph...");  // TODO: use logging facilities
+      mi = dataset.getNamedModel(namedGraph);
+    }
+
+    // Call the patching process
+    System.out.println("Processing: start...");  // TODO: use logging facilities
+    VocabularyManager.run(
+      property2family,
+      vocabularyFolder,
+      dataset,
+      namedGraph,
+      mi,
+      output,
+      lang
+    );
+    System.out.println("Processing: done.");  // TODO: use logging facilities
+    System.exit(0);  // Exit with normal status code.
   }
 
 }
+
+// == EOF =====================================================================

--- a/src/test/java/org/doremus/string2vocabulary/ModuleTest.java
+++ b/src/test/java/org/doremus/string2vocabulary/ModuleTest.java
@@ -1,5 +1,6 @@
 package org.doremus.string2vocabulary;
 
+import org.apache.jena.query.Dataset;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.riot.RDFDataMgr;
@@ -22,10 +23,13 @@ public class ModuleTest {
     String vocabularyFolder = classLoader.getResource("vocabulary").getPath();
 
     try {
-      Model mi = RDFDataMgr.loadModel(input);
-      Model mo = RDFDataMgr.loadModel(output);
-      VocabularyManager.run(property2family, vocabularyFolder, mi, null, "fr");
-      VocabularyManager.run(property2family, vocabularyFolder, mo, null, "fr");
+      String ng = "";
+      Dataset din = RDFDataMgr.loadDataset(input);
+      Dataset dout = RDFDataMgr.loadDataset(output);
+      Model mi = din.getDefaultModel();
+      Model mo = dout.getDefaultModel();
+      VocabularyManager.run(property2family, vocabularyFolder, din,  ng, mi, null, "fr");
+      VocabularyManager.run(property2family, vocabularyFolder, dout, ng, mo, null, "fr");
 
       Assert.assertEquals(toTtlString(mi), toTtlString(mo));
     } catch (IOException e) {

--- a/src/test/resources/input.trig
+++ b/src/test/resources/input.trig
@@ -1,0 +1,42 @@
+@prefix schema: <http://schema.org/> .
+@prefix owl:   <http://www.w3.org/2002/07/owl#> .
+@prefix ecrm:  <http://erlangen-crm.org/current/> .
+@prefix xsd:   <http://www.w3.org/2001/XMLSchema#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix efrbroo: <http://erlangen-crm.org/efrbroo/> .
+@prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix mus:   <http://data.doremus.org/ontology#> .
+@prefix time:  <http://www.w3.org/2006/time#> .
+@prefix prov:  <http://www.w3.org/ns/prov#> .
+@prefix foaf:  <http://xmlns.com/foaf/0.1/> .
+
+# Default graph
+<http://data.doremus.org/expression/001/casting/1/detail/1>
+    a       mus:M23_Casting_Detail ;
+    mus:U2_foresees_use_of_medium_of_performance "mezzosopranos" ;
+    mus:U30_foresees_quantity_of_mop
+            "1"^^xsd:int ;
+    mus:U36_foresees_responsibility
+            "soliste"@fr .
+
+# Named graph "object"
+<http://example.org/graph/object/> {
+        <http://data.doremus.org/expression/002/casting/1/detail/1>
+                a       mus:M23_Casting_Detail ;
+                mus:U2_foresees_use_of_medium_of_performance "mezzosopranos" ;
+                mus:U30_foresees_quantity_of_mop
+                        "1"^^xsd:int ;
+                mus:U36_foresees_responsibility
+                        "soliste"@fr .
+}
+
+# Named graph "other"
+<http://example.org/graph/other/> {
+        <http://data.doremus.org/expression/003/casting/1/detail/1>
+                a       mus:M23_Casting_Detail ;
+                mus:U2_foresees_use_of_medium_of_performance "mezzosopranos" ;
+                mus:U30_foresees_quantity_of_mop
+                        "1"^^xsd:int ;
+                mus:U36_foresees_responsibility
+                        "soliste"@fr .
+}

--- a/src/test/resources/output.trig
+++ b/src/test/resources/output.trig
@@ -1,0 +1,42 @@
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix ecrm:    <http://erlangen-crm.org/current/> .
+@prefix efrbroo: <http://erlangen-crm.org/efrbroo/> .
+@prefix foaf:    <http://xmlns.com/foaf/0.1/> .
+@prefix mus:     <http://data.doremus.org/ontology#> .
+@prefix owl:     <http://www.w3.org/2002/07/owl#> .
+@prefix prov:    <http://www.w3.org/ns/prov#> .
+@prefix rdfs:    <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix schema:  <http://schema.org/> .
+@prefix time:    <http://www.w3.org/2006/time#> .
+@prefix xsd:     <http://www.w3.org/2001/XMLSchema#> .
+
+<http://data.doremus.org/expression/001/casting/1/detail/1>
+        a       mus:M23_Casting_Detail ;
+        mus:U2_foresees_use_of_medium_of_performance
+                "mezzosopranos" ;
+        mus:U30_foresees_quantity_of_mop
+                "1"^^xsd:int ;
+        mus:U36_foresees_responsibility
+                "soliste"@fr .
+
+<http://example.org/graph/other/> {
+    <http://data.doremus.org/expression/003/casting/1/detail/1>
+            a       mus:M23_Casting_Detail ;
+            mus:U2_foresees_use_of_medium_of_performance
+                    "mezzosopranos" ;
+            mus:U30_foresees_quantity_of_mop
+                    "1"^^xsd:int ;
+            mus:U36_foresees_responsibility
+                    "soliste"@fr .
+}
+
+<http://example.org/graph/object/> {
+    <http://data.doremus.org/expression/002/casting/1/detail/1>
+            a       mus:M23_Casting_Detail ;
+            mus:U2_foresees_use_of_medium_of_performance
+                    <http://data.doremus.org/vocabulary/iaml/mop/vms> ;
+            mus:U30_foresees_quantity_of_mop
+                    "1"^^xsd:int ;
+            mus:U36_foresees_responsibility
+                    "soliste"@fr .
+}


### PR DESCRIPTION
Added features:

- Support for [RDF Dataset](https://www.w3.org/TR/sparql11-query/#rdfDataset):
  - replace content at the default graph level
  - replace content at a given named graph level

- Supported textual syntax for RDF (serialization) via file extension checking and generalization of Lang.TRIG output:
  - [RDF Turtle](https://www.w3.org/TR/turtle/) (.ttl)
  - [TriG](https://www.w3.org/TR/trig/) (.trig)

Modifications:

- methods reorganization in VocabularyManager
- javadoc comments in VocabularyManager